### PR TITLE
Export/Import all notes to/from a single JSON file

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("kotlin-android")
     id("org.jetbrains.kotlin.plugin.compose") version libs.versions.kotlin.get()
     id("com.squareup.sqldelight")
+    kotlin("plugin.serialization") version "2.1.0"
 }
 
 repositories {
@@ -111,6 +112,7 @@ dependencies {
     implementation(libs.okio)
     implementation(libs.sqldelight)
     implementation(libs.systemuicontroller)
+    implementation(libs.kotlinjson)
     debugImplementation(libs.compose.ui.tooling)
     coreLibraryDesugaring(libs.android.coreLibraryDesugaring)
 }

--- a/app/src/main/java/com/farmerbb/notepad/ui/components/Menus.kt
+++ b/app/src/main/java/com/farmerbb/notepad/ui/components/Menus.kt
@@ -31,6 +31,7 @@ fun NoteListMenu(
     onMoreClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onImportClick: () -> Unit,
+    onImportAllClick: () -> Unit,
     onExportAllClick: () -> Unit,
     onAboutClick: () -> Unit
 ) {
@@ -42,6 +43,7 @@ fun NoteListMenu(
         ) {
             MenuItem(R.string.action_settings, onSettingsClick)
             MenuItem(R.string.import_notes, onImportClick)
+            MenuItem(R.string.import_all_notes, onImportAllClick)
             MenuItem(R.string.export_all_notes, onExportAllClick)
             MenuItem(R.string.dialog_about_title, onAboutClick)
         }

--- a/app/src/main/java/com/farmerbb/notepad/ui/components/Menus.kt
+++ b/app/src/main/java/com/farmerbb/notepad/ui/components/Menus.kt
@@ -31,6 +31,7 @@ fun NoteListMenu(
     onMoreClick: () -> Unit,
     onSettingsClick: () -> Unit,
     onImportClick: () -> Unit,
+    onExportAllClick: () -> Unit,
     onAboutClick: () -> Unit
 ) {
     Box {
@@ -41,6 +42,7 @@ fun NoteListMenu(
         ) {
             MenuItem(R.string.action_settings, onSettingsClick)
             MenuItem(R.string.import_notes, onImportClick)
+            MenuItem(R.string.export_all_notes, onExportAllClick)
             MenuItem(R.string.dialog_about_title, onAboutClick)
         }
     }

--- a/app/src/main/java/com/farmerbb/notepad/ui/routes/NotepadComposeApp.kt
+++ b/app/src/main/java/com/farmerbb/notepad/ui/routes/NotepadComposeApp.kt
@@ -480,6 +480,10 @@ private fun NotepadComposeApp(
                             onDismiss()
                             vm.importNotes()
                         },
+                        onImportAllClick = {
+                            onDismiss()
+                            vm.importAllNotes()
+                        },
                         onExportAllClick = {
                             onDismiss()
                             vm.exportAllNotes()

--- a/app/src/main/java/com/farmerbb/notepad/ui/routes/NotepadComposeApp.kt
+++ b/app/src/main/java/com/farmerbb/notepad/ui/routes/NotepadComposeApp.kt
@@ -480,6 +480,10 @@ private fun NotepadComposeApp(
                             onDismiss()
                             vm.importNotes()
                         },
+                        onExportAllClick = {
+                            onDismiss()
+                            vm.exportAllNotes()
+                        },
                         onAboutClick = {
                             onDismiss()
                             showAboutDialog = true

--- a/app/src/main/java/com/farmerbb/notepad/usecase/ArtVandelay.kt
+++ b/app/src/main/java/com/farmerbb/notepad/usecase/ArtVandelay.kt
@@ -33,6 +33,7 @@ import java.io.InputStream
 import java.io.OutputStream
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.Date
 import org.koin.dsl.module
 
 interface ArtVandelay {
@@ -45,6 +46,13 @@ interface ArtVandelay {
         hydratedNotes: List<Note>,
         filenameFormat: FilenameFormat,
         saveExportedNote: (OutputStream, String) -> Unit,
+        onCancel: () -> Unit,
+        onComplete: () -> Unit
+    )
+
+    fun exportAllNotes(
+        hydratedNotes: List<Note>,
+        saveExportedNotes: (OutputStream, List<Note>) -> Unit,
         onCancel: () -> Unit,
         onComplete: () -> Unit
     )
@@ -66,6 +74,20 @@ private class ArtVandelayImpl(
         onComplete: (Int) -> Unit
     ) = fileChooser.openChooseMultiSelectFileDialog(
         importCallback(saveImportedNote, onComplete)
+    )
+
+    override fun exportAllNotes(
+        hydratedNotes: List<Note>,
+        saveExportedNotes: (OutputStream, List<Note>) -> Unit,
+        onCancel: () -> Unit,
+        onComplete: () -> Unit,
+    ) = fileChooser.openCreateFileDialog(
+        fileName = generateExportFilename(),
+        fileCreateCallback = exportAllCallback(
+            hydratedNotes,
+            saveExportedNotes,
+            onCancel,
+            onComplete)
     )
 
     override fun exportNotes(
@@ -119,6 +141,23 @@ private class ArtVandelayImpl(
         override fun onCancel(reason: String) = Unit // no-op
     }
 
+    private fun exportAllCallback(
+        hydratedNotes: List<Note>,
+        saveExportedNotes: (OutputStream, List<Note>) -> Unit,
+        onCancel: () -> Unit,
+        onComplete: () -> Unit
+    ) = object: FileCreateCallback() {
+
+        override fun onResult(uri: Uri) {
+            with(fileManager) {
+                fromUri(uri)?.let(::getOutputStream)?.let{ output -> saveExportedNotes(output, hydratedNotes) }
+                onComplete()
+            }
+        }
+
+        override fun onCancel(reason: String) = onCancel()
+    }
+
 
     private fun exportFolderCallback(
         hydratedNotes: List<Note>,
@@ -164,6 +203,15 @@ private class ArtVandelayImpl(
         }
 
         override fun onCancel(reason: String) = Unit // no-op
+    }
+
+    private fun generateExportFilename(): String {
+        val title = "notepad_export"
+        val dateFormat = SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.getDefault())
+        val timestamp = dateFormat.format(Date())
+        val filename = "${title}_$timestamp"
+
+        return "$filename.json.txt"
     }
 
     private fun generateFilename(

--- a/app/src/main/java/com/farmerbb/notepad/utils/Serialization.kt
+++ b/app/src/main/java/com/farmerbb/notepad/utils/Serialization.kt
@@ -12,9 +12,18 @@ import java.util.*
 @Serializable
 data class SerializableNote(val text: String, val title: String, val date: String)
 
+data class DeserializedNote(val text: String, val title: String, val date: Date)
+
 fun serializeNotes(notes: List<Note>) : String {
     val serializableNotes = notes.map { note ->
         val date = SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.getDefault()).format(note.date) ?: ""
         SerializableNote(note.text, note.title, date) }
     return Json.encodeToString(serializableNotes)
+}
+
+fun deserializeNoteJson(text: String): List<DeserializedNote> {
+    val deserializedNotes =Json.decodeFromString<List<SerializableNote>>(text)
+    return deserializedNotes.map { note ->
+        DeserializedNote(note.text, note.title,
+        SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.getDefault()).parse(note.date) ?: Date()) }
 }

--- a/app/src/main/java/com/farmerbb/notepad/utils/Serialization.kt
+++ b/app/src/main/java/com/farmerbb/notepad/utils/Serialization.kt
@@ -1,0 +1,20 @@
+package com.farmerbb.notepad.utils
+
+import com.farmerbb.notepad.model.Note
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import java.text.SimpleDateFormat
+import java.util.*
+
+
+@Serializable
+data class SerializableNote(val text: String, val title: String, val date: String)
+
+fun serializeNotes(notes: List<Note>) : String {
+    val serializableNotes = notes.map { note ->
+        val date = SimpleDateFormat("yyyy-MM-dd-HH-mm", Locale.getDefault()).format(note.date) ?: ""
+        SerializableNote(note.text, note.title, date) }
+    return Json.encodeToString(serializableNotes)
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="first_run">Welcome to Notepad!\n\nTo create a note, click the New Note button (plus sign).</string>
     <string name="first_view">To edit a saved note, double-tap the text or click the Edit button (pencil).</string>
     <string name="import_notes">Import notes</string>
+    <string name="export_all_notes">Export all notes</string>
     <string name="loading_external_file">Failed loading external content (or content type not supported)</string>
     <string name="no_notes_found">No notes found</string>
     <string name="note_deleted">Note deleted</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,6 +51,7 @@
     <string name="first_run">Welcome to Notepad!\n\nTo create a note, click the New Note button (plus sign).</string>
     <string name="first_view">To edit a saved note, double-tap the text or click the Edit button (pencil).</string>
     <string name="import_notes">Import notes</string>
+    <string name="import_all_notes">Import all notes</string>
     <string name="export_all_notes">Export all notes</string>
     <string name="loading_external_file">Failed loading external content (or content type not supported)</string>
     <string name="no_notes_found">No notes found</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ okio = "3.9.0"
 richtext = "0.15.0"
 sqldelight = "1.5.5"
 versionsPlugin = "0.42.0"
+kotlinjson = "1.7.3"
 
 ##################################################################################################################################
 
@@ -79,6 +80,8 @@ linkifyText = { module = "com.github.firefinchdev:linkify-text", version.ref = "
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 sqldelight = { module = "com.squareup.sqldelight:android-driver", version.ref = "sqldelight" }
 systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
+kotlinjson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinjson"}
+
 
 ##################################################################################################################################
 


### PR DESCRIPTION
### Problem Description
A pain point for some users may be that exporting and importing notes can take quite a lot of time if they have on the order of 1000's of notes (for me it takes ~20mins). 

### Diagnosis and Proposed Solution
I ran export in an emulator with profiling and found that creating many files was causing the performance issues. I first tried using a snapshot as recommended by FSAF which is already supposed to be an improvement on the native android framework, but it made little difference. So I decided to try and make export and import work with just a single JSON file. This made export/import almost instant.

### What's Missing
I haven't added translations for any language beside English.

### Issues Out of Scope For Consideration
- I couldn't figure out how to do any exception handling for the coroutines or for exceptions that bubble up through `NotepadActivity.onActivityResult`. If parsing fails the app crashes without any description of what happened.
  - might be nice to have an exception screen like NewPipe does
- `onComplete` for the `ArtVandeley` functions will finish running before the coroutines finish successfully or unsuccessfully.
  - `artVandelay.importNotes` will run the `onComplete` which notifies users that the import of notes was successful before it has actually finished successfully (maybe the toast can be moved inside the coroutine or we can chain coroutines, but I'm not sure)
