### PR TITLE
Improve Editor Usability

### DIFF
--- a/app/src/main/java/com/farmerbb/notepad/model/NavState.kt
+++ b/app/src/main/java/com/farmerbb/notepad/model/NavState.kt
@@ -18,6 +18,7 @@ package com.farmerbb.notepad.model
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.Saver
+import androidx.compose.ui.geometry.Offset
 
 private const val VIEW = "View"
 private const val EDIT = "Edit"
@@ -25,7 +26,7 @@ private const val EDIT = "Edit"
 sealed interface NavState {
     object Empty: NavState
     data class View(val id: Long): NavState
-    data class Edit(val id: Long? = null): NavState
+    data class Edit(val id: Long? = null, val offset: Offset?= null): NavState
 }
 
 val navStateSaver = Saver<MutableState<NavState>, Pair<String, Long?>>(

--- a/app/src/main/java/com/farmerbb/notepad/ui/content/ViewNoteContent.kt
+++ b/app/src/main/java/com/farmerbb/notepad/ui/content/ViewNoteContent.kt
@@ -63,7 +63,7 @@ fun ViewNoteContent(
     isPrinting: Boolean = false,
     showDoubleTapMessage: Boolean = false,
     doubleTapMessageShown: () -> Unit = {},
-    onDoubleTap: () -> Unit = {}
+    onDoubleTap: (Offset?) -> Unit = {}
 ) {
     val textStyle = if (isPrinting) {
         baseTextStyle.copy(color = Color.Black)
@@ -76,23 +76,6 @@ fun ViewNoteContent(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .pointerInteropFilter { motionEvent ->
-                if (motionEvent.action == MotionEvent.ACTION_DOWN) {
-                    val now = System.currentTimeMillis()
-                    val offset = Offset(motionEvent.x, motionEvent.y)
-                    val rect = Rect(center = lastOffset, radius = radius)
-
-                    when {
-                        doubleTapTime > now && rect.contains(offset) -> onDoubleTap()
-                        showDoubleTapMessage -> doubleTapMessageShown()
-                    }
-
-                    doubleTapTime = now + 200
-                    lastOffset = offset
-                }
-
-                false
-            }
     ) {
         Box(
             modifier = if (isPrinting) Modifier else Modifier
@@ -104,6 +87,24 @@ fun ViewNoteContent(
                     vertical = 12.dp
                 )
                 .fillMaxWidth()
+                .pointerInteropFilter { motionEvent ->
+                    if (motionEvent.action == MotionEvent.ACTION_DOWN) {
+                        val now = System.currentTimeMillis()
+                        val offset = Offset(motionEvent.x, motionEvent.y)
+                        val rect = Rect(center = lastOffset, radius = radius)
+
+                        val cursorAtOffset: Offset? = if (!markdown) offset else null
+                        when {
+                            doubleTapTime > now && rect.contains(offset) -> onDoubleTap(cursorAtOffset)
+                            showDoubleTapMessage -> doubleTapMessageShown()
+                        }
+
+                        doubleTapTime = now + 200
+                        lastOffset = offset
+                    }
+
+                    false
+                }
 
             RtlTextWrapper(text, rtlLayout) {
                 SelectionContainer {

--- a/app/src/main/java/com/farmerbb/notepad/ui/routes/NotepadComposeApp.kt
+++ b/app/src/main/java/com/farmerbb/notepad/ui/routes/NotepadComposeApp.kt
@@ -549,7 +549,7 @@ private fun NotepadComposeApp(
                         isPrinting = isPrinting,
                         showDoubleTapMessage = showDoubleTapMessage,
                         doubleTapMessageShown = vm::doubleTapMessageShown
-                    ) { navState = Edit(note.id) }
+                    ) { offset -> navState = Edit(note.id, offset) }
                 }
             }
         }
@@ -599,7 +599,8 @@ private fun NotepadComposeApp(
                         isPrinting = isPrinting,
                         waitForAnimation = note.id == -1L || directEdit,
                         rtlLayout = rtlLayout,
-                        onTextChanged = vm::setText
+                        onTextChanged = vm::setText,
+                        offset = state.offset
                     )
                 }
             }

--- a/app/src/main/java/com/farmerbb/notepad/ui/routes/StandaloneEditor.kt
+++ b/app/src/main/java/com/farmerbb/notepad/ui/routes/StandaloneEditor.kt
@@ -155,7 +155,8 @@ private fun StandaloneEditor(
                 text = text,
                 baseTextStyle = textStyle,
                 isLightTheme = isLightTheme,
-                rtlLayout = rtlLayout
+                rtlLayout = rtlLayout,
+                offset = null
             ) { text = it }
         }
     )


### PR DESCRIPTION
### Issues Fixed
- When using autocorrect and pressing enter to correct a misspelled word instead of replacing the misspelled word with the correction we find the correction is just placed on the next line
  - I assume this happens because `onValueChange` does not execute after all changes are finished while `outputTransformation` happens after all changes to the text state
- When editing a note the keyboard opens to cover the cursor. Instead the text will now scroll to show the cursor
  - I don't know why this is fixed using a different constructor for `BasicTextField` but it seems this has been an issue for a while with this component (https://issuetracker.google.com/issues/237190748)

### New Behavior
When markup/html is disabled double tapping to edit will put the cursor where you tapped instead of at the end of the note. I don't know if this is useful for most users or if there should be a setting to toggle this behavior.

### Tickets Addressed
#157
#158