### PR TITLE
Use collator for locale-aware, case-insensitive sorting

### DIFF
--- a/app/src/main/sqldelight/com/farmerbb/notepad/model/NoteMetadata.sq
+++ b/app/src/main/sqldelight/com/farmerbb/notepad/model/NoteMetadata.sq
@@ -19,11 +19,8 @@ DELETE FROM NoteMetadata WHERE metadataId = :id;
 deleteMultiple:
 DELETE FROM NoteMetadata WHERE metadataId IN ?;
 
-getSortedByTitleDescending:
-SELECT * FROM NoteMetadata ORDER BY title DESC;
-
-getSortedByTitleAscending:
-SELECT * FROM NoteMetadata ORDER BY title ASC;
+getUnsorted:
+SELECT * FROM NoteMetadata;
 
 getSortedByDateDescending:
 SELECT * FROM NoteMetadata ORDER BY date DESC;


### PR DESCRIPTION
Notepad 2.x fixed #8, but 3.x has the same issue again. This PR fixes it